### PR TITLE
Refactor: 이벤트 핸들러 및 함수명을 동사 형태로 변경

### DIFF
--- a/src/features/login/components/LoginButtons.tsx
+++ b/src/features/login/components/LoginButtons.tsx
@@ -14,7 +14,7 @@ const robotoMedium = Roboto({
 });
 
 export const LoginButtons = () => {
-  const { login, loadingProvider } = useAuth();
+  const { handleLogin, loadingProvider } = useAuth();
 
   const isGithubLoading = loadingProvider === SOCIAL_PROVIDER.GITHUB;
   const isGoogleLoading = loadingProvider === SOCIAL_PROVIDER.GOOGLE;
@@ -26,7 +26,7 @@ export const LoginButtons = () => {
       <Button
         variant="outline"
         size="lg"
-        onClick={() => login(SOCIAL_PROVIDER.GITHUB)}
+        onClick={() => handleLogin(SOCIAL_PROVIDER.GITHUB)}
         disabled={isAnyLoading}>
         {isGithubLoading ? <Spinner /> : <BsGithub />}
         {isGithubLoading ? 'GitHub 로그인 중...' : 'GitHub'}
@@ -35,7 +35,7 @@ export const LoginButtons = () => {
         variant="outline"
         size="lg"
         className={robotoMedium.className}
-        onClick={() => login(SOCIAL_PROVIDER.GOOGLE)}
+        onClick={() => handleLogin(SOCIAL_PROVIDER.GOOGLE)}
         disabled={isAnyLoading}>
         {isGoogleLoading ? <Spinner /> : <FcGoogle />}
         {isGoogleLoading ? 'Google 로그인 중...' : 'Google'}

--- a/src/features/sign-up/components/LogoutButton.tsx
+++ b/src/features/sign-up/components/LogoutButton.tsx
@@ -5,14 +5,14 @@ import { Spinner } from '@/components/ui/Spinner';
 import { useAuth } from '@/hooks/useAuth';
 
 export const LogoutButton = ({ className }: { className?: string }) => {
-  const { logout, isLoggingOut } = useAuth();
+  const { handleLogout, isLoggingOut } = useAuth();
 
   return (
     <Button
       className={className}
       type="button"
       variant="outline"
-      onClick={logout}
+      onClick={handleLogout}
       disabled={isLoggingOut}>
       {isLoggingOut ? <Spinner /> : null}
       {isLoggingOut ? '로그아웃 중...' : '로그아웃'}

--- a/src/features/study/components/DropdownAvatar.tsx
+++ b/src/features/study/components/DropdownAvatar.tsx
@@ -14,9 +14,8 @@ import { useAuth } from '@/hooks/useAuth';
 import { useThemeAction } from '@/hooks/useThemeAction';
 
 export const DropdownAvatar = () => {
-  const { logout, isLoggingOut } = useAuth();
+  const { handleLogout, isLoggingOut } = useAuth();
   const { handleToggleTheme, ThemeIcon } = useThemeAction();
-
   const { data: user } = useMyProfileSuspenseQuery();
 
   return (
@@ -56,7 +55,7 @@ export const DropdownAvatar = () => {
 
         <DropdownMenuItem
           className="justify-between"
-          onClick={logout}
+          onClick={handleLogout}
           disabled={isLoggingOut}>
           {isLoggingOut ? <span>로그아웃 중...</span> : <span>로그아웃</span>}
           {isLoggingOut ? <Spinner /> : null}

--- a/src/features/study/components/create/CreateStudyForm.tsx
+++ b/src/features/study/components/create/CreateStudyForm.tsx
@@ -31,9 +31,9 @@ import { Spinner } from '@/components/ui/Spinner';
 import { useCreateStudyForm } from '../../hooks/useCreateStudyForm';
 
 export const CreateStudyForm = () => {
-  const { form, onQuit, isSubmitting } = useCreateStudyForm();
+  const { form, handleQuit, isSubmitting } = useCreateStudyForm();
 
-  const handleNumberChange = (
+  const handleChangeNumber = (
     e: React.ChangeEvent<HTMLInputElement>,
     onChange: (value: number | null) => void,
   ) => {
@@ -211,7 +211,7 @@ export const CreateStudyForm = () => {
                         value={field.state.value ?? ''}
                         onBlur={field.handleBlur}
                         onChange={(e) =>
-                          handleNumberChange(e, field.handleChange)
+                          handleChangeNumber(e, field.handleChange)
                         }
                         data-invalid={isInvalid}
                       />
@@ -243,7 +243,7 @@ export const CreateStudyForm = () => {
                         value={field.state.value ?? ''}
                         onBlur={field.handleBlur}
                         onChange={(e) =>
-                          handleNumberChange(e, field.handleChange)
+                          handleChangeNumber(e, field.handleChange)
                         }
                         data-invalid={isInvalid}
                       />
@@ -286,7 +286,7 @@ export const CreateStudyForm = () => {
               variant="outline"
               type="button"
               className="order-2 @md/field-group:order-1"
-              onClick={onQuit}
+              onClick={handleQuit}
               disabled={isSubmitting}>
               뒤로
             </Button>

--- a/src/features/study/components/home/studies/Studies.tsx
+++ b/src/features/study/components/home/studies/Studies.tsx
@@ -20,7 +20,7 @@ export const Studies = ({ initialData }: Props) => {
   const [isNavigating, startTransition] = useTransition();
   const { data } = useMyStudiesQuery({ initialData });
 
-  const onClickRow = (study: GetMyStudiesResponse) => {
+  const moveToStudyMain = (study: GetMyStudiesResponse) => {
     if (isNavigating) {
       return;
     }
@@ -39,7 +39,7 @@ export const Studies = ({ initialData }: Props) => {
     <StudiesTable
       data={data ?? []}
       columns={STUDIES_TABLE_COLUMNS}
-      onClickRow={onClickRow}
+      onClickRow={moveToStudyMain}
     />
   );
 };

--- a/src/features/study/components/home/studies/StudiesTableHeader.tsx
+++ b/src/features/study/components/home/studies/StudiesTableHeader.tsx
@@ -12,11 +12,11 @@ import { useRouter } from 'next/navigation';
 export const StudiesTableHeader = () => {
   const router = useRouter();
 
-  const onClickCreate = () => {
+  const moveToCreateStudy = () => {
     router.push(PATH.STUDY.CREATE);
   };
 
-  const onClickJoin = () => {
+  const moveToJoinStudy = () => {
     router.push(PATH.STUDY.JOIN);
   };
 
@@ -30,14 +30,14 @@ export const StudiesTableHeader = () => {
         <Button
           variant="secondary"
           size="icon-sm-responsive"
-          onClick={onClickCreate}>
+          onClick={moveToCreateStudy}>
           <PlusIcon />
           <span className="hidden sm:inline">새로 만들기</span>
         </Button>
         <Button
           variant="secondary"
           size="icon-sm-responsive"
-          onClick={onClickJoin}>
+          onClick={moveToJoinStudy}>
           <GitPullRequestArrowIcon />
           <span className="hidden sm:inline">들어가기</span>
         </Button>

--- a/src/features/study/components/join/JoinStudyForm.tsx
+++ b/src/features/study/components/join/JoinStudyForm.tsx
@@ -16,7 +16,7 @@ import { Spinner } from '@/components/ui/Spinner';
 import { useJoinStudyForm } from '../../hooks/useJoinStudyForm';
 
 export const JoinStudyForm = () => {
-  const { form, onQuit, isSubmitting } = useJoinStudyForm();
+  const { form, handleQuit, isSubmitting } = useJoinStudyForm();
 
   return (
     <form
@@ -69,7 +69,7 @@ export const JoinStudyForm = () => {
               variant="outline"
               type="button"
               className="order-2 @md/field-group:order-1"
-              onClick={onQuit}
+              onClick={handleQuit}
               disabled={isSubmitting}>
               뒤로
             </Button>

--- a/src/features/study/components/main/StudyMainHeader.tsx
+++ b/src/features/study/components/main/StudyMainHeader.tsx
@@ -24,7 +24,6 @@ import { DropdownAvatar } from '../DropdownAvatar';
 
 const BREADCRUMB_MAP: Record<string, string> = {
   setting: '스터디 설정',
-  /** @todo 문제 풀이 글 목록 화면 같은거 만들어야 할 듯 함*/
   note: '문제 풀이 글',
   template: '템플릿 수정',
   write: '작성',
@@ -67,7 +66,7 @@ export const StudyMainHeader = ({ studyId, initialData }: Props) => {
     pathParams: { studyId: study.id },
   });
 
-  const onClickSetting = () => {
+  const moveToSetting = () => {
     router.push(settingPageUrl);
   };
 
@@ -128,7 +127,7 @@ export const StudyMainHeader = ({ studyId, initialData }: Props) => {
       </Breadcrumb>
 
       <div className="flex flex-row items-center gap-2">
-        <Button variant="outline" size="icon-sm" onClick={onClickSetting}>
+        <Button variant="outline" size="icon-sm" onClick={moveToSetting}>
           <SettingsIcon />
         </Button>
 

--- a/src/features/study/components/main/daily-assignments/AssignmentAddDialog.tsx
+++ b/src/features/study/components/main/daily-assignments/AssignmentAddDialog.tsx
@@ -24,7 +24,7 @@ export const AssignmentAddDialog = () => {
     setBojNumber,
     open,
     handleOpenChange,
-    onSubmit,
+    handleSubmit,
     canSubmit,
     isAdding,
   } = useAddAssignment();
@@ -67,7 +67,7 @@ export const AssignmentAddDialog = () => {
           <Button
             type="submit"
             disabled={!canSubmit || isAdding}
-            onClick={onSubmit}>
+            onClick={handleSubmit}>
             {isAdding ? <Spinner /> : null}
             {isAdding ? '추가 중...' : '추가'}
           </Button>

--- a/src/features/study/components/main/daily-assignments/DailyAssignments.tsx
+++ b/src/features/study/components/main/daily-assignments/DailyAssignments.tsx
@@ -15,7 +15,7 @@ type Props = {
 };
 
 export const DailyAssignments = ({ studyId, initialData, role }: Props) => {
-  const { data, isRefreshing, onRefresh } = useDailyAssignments({
+  const { data, isRefreshing, handleRefresh } = useDailyAssignments({
     initialData,
   });
 
@@ -29,7 +29,7 @@ export const DailyAssignments = ({ studyId, initialData, role }: Props) => {
       <DailyAssignmentsTableFooter
         refreshedAt={data?.refreshedAt ?? ''}
         isRefreshing={isRefreshing}
-        onRefresh={onRefresh}
+        onRefresh={handleRefresh}
         role={role}
       />
     </div>

--- a/src/features/study/components/main/notes/Notes.tsx
+++ b/src/features/study/components/main/notes/Notes.tsx
@@ -33,7 +33,7 @@ export const Notes = ({ studyId, problemId, pageSize, initialData }: Props) => {
     },
   );
 
-  const handleRowClick = (note: GetNoteDetailResponse) => {
+  const moveToNoteDetail = (note: GetNoteDetailResponse) => {
     if (isNavigating) {
       return;
     }
@@ -56,7 +56,7 @@ export const Notes = ({ studyId, problemId, pageSize, initialData }: Props) => {
       <NotesTable
         data={data?.results ?? []}
         columns={NOTES_TABLE_COLUMNS}
-        onClickRow={handleRowClick}
+        onClickRow={moveToNoteDetail}
       />
 
       <div className="text-muted-foreground flex flex-col items-end justify-end gap-1 text-xs">

--- a/src/features/study/components/main/notes/NotesTableHeader.tsx
+++ b/src/features/study/components/main/notes/NotesTableHeader.tsx
@@ -17,7 +17,7 @@ export const NotesTableHeader = ({ studyId, role }: Props) => {
 
   const isEditable = role === STUDY_ROLE.OWNER;
 
-  const handleClickTemplate = () => {
+  const moveToManageTemplate = () => {
     router.push(
       buildUrlWithParams({
         url: PATH.STUDY.NOTE.TEMPLATE,
@@ -26,7 +26,7 @@ export const NotesTableHeader = ({ studyId, role }: Props) => {
     );
   };
 
-  const handleClickMaximize = () => {
+  const moveToMaximize = () => {
     router.push(
       buildUrlWithParams({
         url: PATH.STUDY.NOTE.LIST,
@@ -46,7 +46,7 @@ export const NotesTableHeader = ({ studyId, role }: Props) => {
           <Button
             variant="secondary"
             size="icon-sm-responsive"
-            onClick={handleClickTemplate}>
+            onClick={moveToManageTemplate}>
             <FileCog2Icon />
             <span className="hidden sm:inline">템플릿 관리</span>
           </Button>
@@ -55,7 +55,7 @@ export const NotesTableHeader = ({ studyId, role }: Props) => {
         <Button
           variant="secondary"
           size="icon-sm-responsive"
-          onClick={handleClickMaximize}>
+          onClick={moveToMaximize}>
           <Maximize2Icon />
           <span className="hidden sm:inline">전체 페이지로 보기</span>
         </Button>

--- a/src/features/study/components/note/detail/NoteActionButtons.tsx
+++ b/src/features/study/components/note/detail/NoteActionButtons.tsx
@@ -26,7 +26,7 @@ export const NoteActionButtons = ({ studyId, noteId }: Props) => {
   const router = useRouter();
   const { handleRemove, isRemoving } = useRemoveNote();
 
-  const handleUpdate = () => {
+  const moveToEditNote = () => {
     router.push(
       buildUrlWithParams({
         url: PATH.STUDY.NOTE.EDIT,
@@ -40,7 +40,7 @@ export const NoteActionButtons = ({ studyId, noteId }: Props) => {
       <button
         type="button"
         className="text-muted-foreground hover:text-foreground transition-colors hover:cursor-pointer hover:font-medium"
-        onClick={handleUpdate}>
+        onClick={moveToEditNote}>
         수정
       </button>
 

--- a/src/features/study/components/note/editor/NoteTemplateUpdateEditor.tsx
+++ b/src/features/study/components/note/editor/NoteTemplateUpdateEditor.tsx
@@ -12,14 +12,14 @@ export const NoteTemplateUpdateEditor = ({ initialTemplate }: Props) => {
     templateContent,
     isDirty,
     isSubmitting,
-    onChange,
-    onSubmit,
-    onReset,
+    handleChange,
+    handleSubmit,
+    resetForm,
   } = useUpdateNoteTemplate({ initialTemplate });
 
-  const onClickReset = () => {
+  const handleReset = () => {
     if (confirm('작성 중인 내용이 초기화됩니다. 계속하시겠습니까?')) {
-      onReset();
+      resetForm();
     }
   };
 
@@ -27,10 +27,10 @@ export const NoteTemplateUpdateEditor = ({ initialTemplate }: Props) => {
     <div className="h-[calc(100dvh-6.25rem)] w-full overflow-hidden lg:h-[calc(100dvh-7rem)]">
       <DynamicMarkdownEditor
         value={templateContent}
-        onChange={onChange}
+        onChange={handleChange}
         placeholder="풀이 노트 템플릿을 작성해보세요."
-        onSubmit={onSubmit}
-        onReset={onClickReset}
+        onSubmit={handleSubmit}
+        onReset={handleReset}
         isSubmitting={isSubmitting}
         isDirty={isDirty}
       />

--- a/src/features/study/components/note/editor/NoteUpdateEditor.tsx
+++ b/src/features/study/components/note/editor/NoteUpdateEditor.tsx
@@ -2,19 +2,25 @@
 
 import { DynamicMarkdownEditor } from '@/components/common/MarkdownEditor';
 
-import { useUpdateNote } from '../../../hooks/useEditNote';
+import { useEditNote } from '../../../hooks/useEditNote';
 
 type Props = {
   initialContent: string;
 };
 
 export const NoteUpdateEditor = ({ initialContent }: Props) => {
-  const { content, isDirty, isSubmitting, onChange, onSubmit, onReset } =
-    useUpdateNote({ initialContent });
+  const {
+    content,
+    isDirty,
+    isSubmitting,
+    handleChange,
+    handleSubmit,
+    resetForm,
+  } = useEditNote({ initialContent });
 
-  const onClickReset = () => {
+  const handleReset = () => {
     if (confirm('작성 중인 내용이 초기화됩니다. 계속하시겠습니까?')) {
-      onReset();
+      resetForm();
     }
   };
 
@@ -22,10 +28,10 @@ export const NoteUpdateEditor = ({ initialContent }: Props) => {
     <div className="h-[calc(100dvh-6.25rem)] w-full overflow-hidden lg:h-[calc(100dvh-7rem)]">
       <DynamicMarkdownEditor
         value={content}
-        onChange={onChange}
         placeholder="풀이 노트를 수정하세요."
-        onSubmit={onSubmit}
-        onReset={onClickReset}
+        onChange={handleChange}
+        onSubmit={handleSubmit}
+        onReset={handleReset}
         isSubmitting={isSubmitting}
         isDirty={isDirty}
       />

--- a/src/features/study/components/note/editor/NoteWriteEditor.tsx
+++ b/src/features/study/components/note/editor/NoteWriteEditor.tsx
@@ -10,12 +10,18 @@ type Props = {
 };
 
 export const NoteWriteEditor = ({ problemId, initialContent }: Props) => {
-  const { content, isDirty, isSubmitting, onChange, onSubmit, onReset } =
-    useWriteNote({ problemId, initialContent });
+  const {
+    content,
+    isDirty,
+    isSubmitting,
+    handleChange,
+    handleSubmit,
+    resetForm,
+  } = useWriteNote({ problemId, initialContent });
 
-  const onClickReset = () => {
+  const handleReset = () => {
     if (confirm('작성 중인 내용이 초기화됩니다. 계속하시겠습니까?')) {
-      onReset();
+      resetForm();
     }
   };
 
@@ -23,10 +29,10 @@ export const NoteWriteEditor = ({ problemId, initialContent }: Props) => {
     <div className="h-[calc(100dvh-6.25rem)] w-full overflow-hidden lg:h-[calc(100dvh-7rem)]">
       <DynamicMarkdownEditor
         value={content}
-        onChange={onChange}
+        onChange={handleChange}
         placeholder="어떻게 문제를 풀었는지 기록해보세요."
-        onSubmit={onSubmit}
-        onReset={onClickReset}
+        onSubmit={handleSubmit}
+        onReset={handleReset}
         isSubmitting={isSubmitting}
         isDirty={isDirty}
       />

--- a/src/features/study/components/note/notes-maximize/NotesMaximize.tsx
+++ b/src/features/study/components/note/notes-maximize/NotesMaximize.tsx
@@ -55,8 +55,10 @@ export const NotesMaximize = ({
   const isFiltered =
     !!debouncedQuery || !!formattedAssignedDate || !!formattedUpdatedDate;
 
-  const handleRowClick = (note: GetNoteDetailResponse) => {
-    if (isNavigating) return;
+  const moveToNoteDetail = (note: GetNoteDetailResponse) => {
+    if (isNavigating) {
+      return;
+    }
 
     startTransition(() => {
       router.push(
@@ -88,7 +90,7 @@ export const NotesMaximize = ({
         columns={NOTES_TABLE_COLUMNS}
         isLoading={isLoading}
         isFiltered={isFiltered}
-        onClickRow={handleRowClick}
+        onClickRow={moveToNoteDetail}
         onLoadMore={fetchNextPage}
         hasNextPage={hasNextPage}
         isFetchingNextPage={isFetchingNextPage}

--- a/src/features/study/components/note/notes-maximize/NotesMaximizeTableHeader.tsx
+++ b/src/features/study/components/note/notes-maximize/NotesMaximizeTableHeader.tsx
@@ -15,7 +15,7 @@ export const NotesMaximizeTableHeader = ({ studyId, role }: Props) => {
 
   const isEditable = role === STUDY_ROLE.OWNER;
 
-  const handleTemplateManageClick = () => {
+  const moveToManageTemplate = () => {
     router.push(
       buildUrlWithParams({
         url: PATH.STUDY.NOTE.TEMPLATE,
@@ -34,7 +34,7 @@ export const NotesMaximizeTableHeader = ({ studyId, role }: Props) => {
         <Button
           variant="secondary"
           size="icon-responsive"
-          onClick={handleTemplateManageClick}>
+          onClick={moveToManageTemplate}>
           <FileCog2Icon />
           <span className="hidden sm:inline">템플릿 관리</span>
         </Button>

--- a/src/features/study/components/setting/danger-zone/StudyLeaveRow.tsx
+++ b/src/features/study/components/setting/danger-zone/StudyLeaveRow.tsx
@@ -24,7 +24,7 @@ import { useExitStudy } from '@/features/study/hooks/useExitStudy';
 export const StudyLeaveRow = () => {
   const { mutateLeaveStudy, isLeavingStudy } = useExitStudy();
 
-  const onClick = () => {
+  const handleLeaveStudy = () => {
     if (!isLeavingStudy) {
       mutateLeaveStudy();
     }
@@ -62,7 +62,7 @@ export const StudyLeaveRow = () => {
               </DialogClose>
               <Button
                 variant="destructive"
-                onClick={onClick}
+                onClick={handleLeaveStudy}
                 disabled={isLeavingStudy}>
                 {isLeavingStudy ? <Spinner /> : null}
                 {isLeavingStudy ? '탈퇴 중...' : '스터디 탈퇴'}

--- a/src/features/study/components/setting/danger-zone/StudyRemoveRow.tsx
+++ b/src/features/study/components/setting/danger-zone/StudyRemoveRow.tsx
@@ -36,7 +36,7 @@ export const StudyRemoveRow = ({ studyName }: Props) => {
     handleConfirmTextChange,
     handleOpenChange,
     open,
-    onSubmit,
+    handleSubmit,
     isRemovingStudy,
   } = useRemoveConfirmation({ expectedText });
 
@@ -82,7 +82,7 @@ export const StudyRemoveRow = ({ studyName }: Props) => {
               <Button
                 variant="destructive"
                 disabled={!isConfirmValid || isRemovingStudy}
-                onClick={onSubmit}>
+                onClick={handleSubmit}>
                 {isRemovingStudy ? <Spinner /> : null}
                 {isRemovingStudy ? '삭제 중...' : '스터디 삭제'}
               </Button>

--- a/src/features/study/components/setting/study-info/UpdateStudyForm.tsx
+++ b/src/features/study/components/setting/study-info/UpdateStudyForm.tsx
@@ -35,13 +35,13 @@ type Props = {
 };
 
 export const UpdateStudyForm = ({ initialData, role }: Props) => {
-  const { form, onReset, isSubmitting } = useUpdateStudyForm({
+  const { form, resetForm, isSubmitting } = useUpdateStudyForm({
     initialData,
   });
 
   const isEditable = role === STUDY_ROLE.OWNER;
 
-  const handleNumberChange = (
+  const handleChangeNumber = (
     e: React.ChangeEvent<HTMLInputElement>,
     onChange: (value: number | null) => void,
   ) => {
@@ -223,7 +223,7 @@ export const UpdateStudyForm = ({ initialData, role }: Props) => {
                         value={field.state.value ?? ''}
                         onBlur={field.handleBlur}
                         onChange={(e) =>
-                          handleNumberChange(e, field.handleChange)
+                          handleChangeNumber(e, field.handleChange)
                         }
                         data-invalid={isInvalid}
                       />
@@ -256,7 +256,7 @@ export const UpdateStudyForm = ({ initialData, role }: Props) => {
                         value={field.state.value ?? ''}
                         onBlur={field.handleBlur}
                         onChange={(e) =>
-                          handleNumberChange(e, field.handleChange)
+                          handleChangeNumber(e, field.handleChange)
                         }
                         data-invalid={isInvalid}
                       />
@@ -316,7 +316,7 @@ export const UpdateStudyForm = ({ initialData, role }: Props) => {
                       confirm(
                         '작성 중인 내용이 초기화됩니다. 계속하시겠습니까?',
                       )
-                        ? onReset()
+                        ? resetForm()
                         : null
                     }
                     disabled={!isDirty || isSubmitting}>

--- a/src/features/study/hooks/useAddAssignment.ts
+++ b/src/features/study/hooks/useAddAssignment.ts
@@ -52,20 +52,16 @@ export const useAddAssignment = () => {
     setOpen(isOpen);
 
     if (!isOpen) {
-      onReset();
+      setBojNumber('');
     }
   };
 
-  const onSubmit = () => {
+  const handleSubmit = () => {
     if (isAdding || !bojNumber.trim()) {
       return;
     }
 
     mutateAddAssignment({ bojNumber: parseInt(bojNumber, 10) });
-  };
-
-  const onReset = () => {
-    setBojNumber('');
   };
 
   return {
@@ -74,7 +70,7 @@ export const useAddAssignment = () => {
     open,
     setOpen,
     handleOpenChange,
-    onSubmit,
+    handleSubmit,
     canSubmit: !isAdding && bojNumber.trim(),
     isAdding,
   };

--- a/src/features/study/hooks/useCreateStudyForm.ts
+++ b/src/features/study/hooks/useCreateStudyForm.ts
@@ -66,14 +66,14 @@ export const useCreateStudyForm = () => {
     },
   });
 
-  const onQuit = async () => {
+  const handleQuit = () => {
     form.reset();
     router.back();
   };
 
   return {
     form,
-    onQuit,
+    handleQuit,
     isSubmitting: isCreating || isNavigating,
   };
 };

--- a/src/features/study/hooks/useDailyAssignments.ts
+++ b/src/features/study/hooks/useDailyAssignments.ts
@@ -36,7 +36,7 @@ export const useDailyAssignments = ({ initialData }: Props) => {
       },
     });
 
-  const onRefresh = () => {
+  const handleRefresh = () => {
     if (isPending) {
       return;
     }
@@ -63,6 +63,6 @@ export const useDailyAssignments = ({ initialData }: Props) => {
   return {
     data,
     isRefreshing: isPending || isRefetching,
-    onRefresh,
+    handleRefresh,
   };
 };

--- a/src/features/study/hooks/useEditNote.ts
+++ b/src/features/study/hooks/useEditNote.ts
@@ -12,7 +12,7 @@ type Props = {
   initialContent: string;
 };
 
-export const useUpdateNote = ({ initialContent }: Props) => {
+export const useEditNote = ({ initialContent }: Props) => {
   const studyId = useParamInt('studyId');
   const noteId = useParamInt('noteId');
   const router = useRouter();
@@ -65,11 +65,11 @@ export const useUpdateNote = ({ initialContent }: Props) => {
       },
     });
 
-  const onChange = (value?: string) => {
+  const handleChange = (value?: string) => {
     setContent(value || '');
   };
 
-  const onSubmit = () => {
+  const handleSubmit = () => {
     if (isUpdating) {
       return;
     }
@@ -77,7 +77,7 @@ export const useUpdateNote = ({ initialContent }: Props) => {
     mutateUpdateNote({ content });
   };
 
-  const onReset = () => {
+  const resetForm = () => {
     setContent(initialContent);
   };
 
@@ -85,8 +85,8 @@ export const useUpdateNote = ({ initialContent }: Props) => {
     content,
     isDirty: content.trim().length > 0 && content !== initialContent,
     isSubmitting: isUpdating || isNavigating,
-    onChange,
-    onSubmit,
-    onReset,
+    handleChange,
+    handleSubmit,
+    resetForm,
   };
 };

--- a/src/features/study/hooks/useJoinStudyForm.ts
+++ b/src/features/study/hooks/useJoinStudyForm.ts
@@ -75,14 +75,14 @@ export const useJoinStudyForm = () => {
     },
   });
 
-  const onQuit = async () => {
+  const handleQuit = () => {
     form.reset();
     router.back();
   };
 
   return {
     form,
-    onQuit,
+    handleQuit,
     isSubmitting: isJoining || isNavigating,
   };
 };

--- a/src/features/study/hooks/useRemoveConfirmation.ts
+++ b/src/features/study/hooks/useRemoveConfirmation.ts
@@ -17,7 +17,7 @@ export const useRemoveConfirmation = ({ expectedText }: Props) => {
     setOpen(isOpen);
 
     if (!isOpen) {
-      onReset();
+      setConfirmText('');
     }
   };
 
@@ -25,14 +25,10 @@ export const useRemoveConfirmation = ({ expectedText }: Props) => {
     setConfirmText(value);
   };
 
-  const onSubmit = () => {
+  const handleSubmit = () => {
     if (isConfirmValid) {
       mutateRemoveStudy();
     }
-  };
-
-  const onReset = () => {
-    setConfirmText('');
   };
 
   return {
@@ -40,8 +36,7 @@ export const useRemoveConfirmation = ({ expectedText }: Props) => {
     isConfirmValid,
     handleOpenChange,
     handleConfirmTextChange,
-    onSubmit,
-    onReset,
+    handleSubmit,
     open,
     isRemovingStudy,
   };

--- a/src/features/study/hooks/useUpdateNoteTemplate.ts
+++ b/src/features/study/hooks/useUpdateNoteTemplate.ts
@@ -32,11 +32,11 @@ export const useUpdateNoteTemplate = ({ initialTemplate }: Props) => {
       },
     });
 
-  const onChange = (value?: string) => {
+  const handleChange = (value?: string) => {
     setTemplateContent(value || '');
   };
 
-  const onSubmit = () => {
+  const handleSubmit = () => {
     if (isUpdating) {
       return;
     }
@@ -44,7 +44,7 @@ export const useUpdateNoteTemplate = ({ initialTemplate }: Props) => {
     mutateUpdateNoteTemplate({ templateContent });
   };
 
-  const onReset = () => {
+  const resetForm = () => {
     setTemplateContent(initialTemplate);
   };
 
@@ -53,8 +53,8 @@ export const useUpdateNoteTemplate = ({ initialTemplate }: Props) => {
     isDirty:
       templateContent.trim().length > 0 && templateContent !== initialTemplate,
     isSubmitting: isUpdating || isNavigating,
-    onChange,
-    onSubmit,
-    onReset,
+    handleChange,
+    handleSubmit,
+    resetForm,
   };
 };

--- a/src/features/study/hooks/useUpdateStudyForm.ts
+++ b/src/features/study/hooks/useUpdateStudyForm.ts
@@ -54,13 +54,13 @@ export const useUpdateStudyForm = ({ initialData }: Props) => {
     },
   });
 
-  const onReset = () => {
+  const resetForm = () => {
     form.reset(initialData);
   };
 
   return {
     form,
     isSubmitting: isUpdating || isRefreshing,
-    onReset,
+    resetForm,
   };
 };

--- a/src/features/study/hooks/useWriteNote.ts
+++ b/src/features/study/hooks/useWriteNote.ts
@@ -67,11 +67,11 @@ export const useWriteNote = ({ problemId, initialContent }: Props) => {
       },
     });
 
-  const onChange = (value?: string) => {
+  const handleChange = (value?: string) => {
     setContent(value || '');
   };
 
-  const onSubmit = () => {
+  const handleSubmit = () => {
     if (isWriting) {
       return;
     }
@@ -88,7 +88,7 @@ export const useWriteNote = ({ problemId, initialContent }: Props) => {
     mutateWriteNote({ problemId, content });
   };
 
-  const onReset = () => {
+  const resetForm = () => {
     setContent(initialContent);
   };
 
@@ -96,8 +96,8 @@ export const useWriteNote = ({ problemId, initialContent }: Props) => {
     content,
     isDirty: content.trim().length > 0 && content !== initialContent,
     isSubmitting: isWriting || isNavigating,
-    onChange,
-    onSubmit,
-    onReset,
+    handleChange,
+    handleSubmit,
+    resetForm,
   };
 };

--- a/src/features/study/suspenses/NotesMaximizeSuspense.tsx
+++ b/src/features/study/suspenses/NotesMaximizeSuspense.tsx
@@ -8,35 +8,16 @@ type Props = {
   study: GetStudyDetailResponse;
   problemId?: number;
   pageSize?: number;
-  assignedDate?: string;
-  bojNumber?: number;
-  problemTitle?: string;
-  updatedDate?: string;
-  writer?: string;
 };
 
 export const NotesMaximizeSuspense = withSuspense(
-  ({
-    study,
-    problemId,
-    pageSize,
-    assignedDate,
-    bojNumber,
-    problemTitle,
-    updatedDate,
-    writer,
-  }: Props) => {
+  ({ study, problemId, pageSize }: Props) => {
     return (
       <NotesMaximize
         studyId={study.id}
         role={study.myRole}
         problemId={problemId}
         pageSize={pageSize}
-        assignedDate={assignedDate}
-        bojNumber={bojNumber}
-        problemTitle={problemTitle}
-        updatedDate={updatedDate}
-        writer={writer}
       />
     );
   },

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -12,7 +12,7 @@ export const useAuth = () => {
     null,
   );
 
-  const login = useCallback(async (provider: SocialProvider) => {
+  const handleLogin = useCallback(async (provider: SocialProvider) => {
     try {
       setLoadingProvider(provider);
 
@@ -43,7 +43,7 @@ export const useAuth = () => {
     },
   });
 
-  const logout = useCallback(async () => {
+  const handleLogout = useCallback(async () => {
     if (isLoggingOut) {
       return;
     }
@@ -55,8 +55,8 @@ export const useAuth = () => {
     session,
     loadingProvider,
     isLoggingOut,
-    login,
-    logout,
+    handleLogin,
+    handleLogout,
     updateSession,
   };
 };


### PR DESCRIPTION
### 🚀 개요 (Overview)

<!---
이 PR의 목적과 배경을 간략하게 설명해주세요.

예시)
[ resolves #1 ]

- 로그인 기능 추가
- 특정 버그 수정
-->

[ resolves #44 ]

- `on`으로 시작되는 함수명은 `handle` 혹은 `move`로 시작하도록 변경
